### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/devworxsoftware/99c801fc-ae41-4464-8fb4-6a05cad8fb9d/4b2b10e0-70a7-4f39-86b4-bb85e07475f3/_apis/work/boardbadge/c17b263a-51b6-432e-b45b-d243d7af3763)](https://dev.azure.com/devworxsoftware/99c801fc-ae41-4464-8fb4-6a05cad8fb9d/_boards/board/t/4b2b10e0-70a7-4f39-86b4-bb85e07475f3/Microsoft.RequirementCategory)
 # git-test-repo
 testing the github features


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1031](https://dev.azure.com/devworxsoftware/99c801fc-ae41-4464-8fb4-6a05cad8fb9d/_workitems/edit/1031). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.